### PR TITLE
Add IC-GD experiment pipeline

### DIFF
--- a/experiments/ic_gd/README.md
+++ b/experiments/ic_gd/README.md
@@ -1,0 +1,28 @@
+# In-Context GD Experiment Integration Plan
+
+This repository already provides flexible Transformer components implemented in JAX/Haiku (`src/transformer.py`), attention utilities (`src/attn.py`), configuration defaults (`src/config.py`), and the existing training harness (`src/train.py`). The new in-context gradient descent (IC-GD) replication stack will live under `experiments/ic_gd/` and reuse the core model where possible while offering a PyTorch-based pipeline specialised for the linear regression benchmark.
+
+## Existing building blocks
+- **Model** (`src/transformer.py`): defines a configurable Transformer with optional attention-only mode, positional encodings, and DEQ-style recurrence. We will instantiate this module for the IC-GD experiment by mirroring key hyperparameters (depth, heads, embedding size) inside experiment-specific configs.
+- **Attention utilities** (`src/attn.py`): provides multi-head attention, MLP blocks, layer norm, and token embedding helpers. The IC-GD training script will import these abstractions when constructing the Transformer backbone.
+- **Configuration** (`src/config.py`): exposes a `ConfigDict` describing model/data defaults. We will build experiment-specific YAML configs that feed a lightweight dataclass mirroring the same fields to keep interoperability with analysis notebooks.
+- **Training utilities** (`src/train.py`): contains the Haiku/Optax loop that current experiments use. The IC-GD training entry point will take inspiration from this structure but operate directly in PyTorch, while keeping logging and checkpoint conventions compatible.
+
+## New experiment files
+The IC-GD workflow introduces the following files:
+
+```
+experiments/ic_gd/
+  data.py              # LinearRegressionTaskset dataset & task sampling utilities
+  gd_baseline.py       # Closed-form gradient descent simulator + CLI
+  io.py                # Sequence packing & masking helpers for transformer inputs
+  heads.py             # Shared linear readout & layerwise evaluation helpers
+  train_transformer.py # Training script for transformer on IC-GD tasks
+  eval_layerwise.py    # Script to evaluate layerwise losses on checkpoints
+  plot_compare.py      # Plotting utility to compare GD baseline vs transformer
+  utils.py             # Shared helpers (seeding, logging)
+  configs/
+    linreg.yaml        # Default configuration for the replication experiment
+```
+
+These components collectively implement the plan in `plans/experiment_replication.md` while minimising duplication with core modules. Subsequent steps will populate each file with the required functionality.

--- a/experiments/ic_gd/configs/linreg.yaml
+++ b/experiments/ic_gd/configs/linreg.yaml
@@ -1,0 +1,29 @@
+seed: 1
+save_dir: runs/ic_gd/d20_L12
+
+dataset:
+  d: 20
+  n_context: 20
+  n_query: 20
+  sigma_w: 1.0
+  sigma_eps: 0.05
+  n_tasks: 50000
+
+model:
+  d_model: 128
+  n_heads: 4
+  ff_mult: 4
+  depth: 12
+  dropout: 0.0
+
+training:
+  batch_size: 64
+  steps: 50000
+  lr: 1.0e-4
+  weight_decay: 0.01
+  warmup: 2000
+  eval_interval: 1000
+  grad_clip: 1.0
+
+eval:
+  nsamples: 5000

--- a/experiments/ic_gd/data.py
+++ b/experiments/ic_gd/data.py
@@ -1,0 +1,148 @@
+"""Task sampling utilities for in-context GD experiments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import torch
+from torch.utils.data import Dataset
+
+
+@dataclass(frozen=True)
+class LinearRegressionTasksetConfig:
+    """Configuration for :class:`LinearRegressionTaskset`."""
+
+    d: int
+    n_context: int
+    n_query: int
+    sigma_w: float
+    sigma_eps: float
+    n_tasks: int
+    seed: int = 0
+    device: Optional[torch.device] = None
+    dtype: torch.dtype = torch.float32
+
+
+class LinearRegressionTaskset(Dataset):
+    """Dataset of synthetic linear regression tasks with Gaussian data."""
+
+    def __init__(
+        self,
+        d: int,
+        n_context: int,
+        n_query: int,
+        sigma_w: float,
+        sigma_eps: float,
+        n_tasks: int,
+        seed: int = 0,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        super().__init__()
+        if d <= 0:
+            raise ValueError("Feature dimension must be positive.")
+        if n_context <= 0 or n_query <= 0:
+            raise ValueError("Context and query counts must be positive.")
+        if sigma_w < 0 or sigma_eps < 0:
+            raise ValueError("Scales must be non-negative.")
+        if n_tasks <= 0:
+            raise ValueError("Number of tasks must be positive.")
+
+        self.d = d
+        self.n_context = n_context
+        self.n_query = n_query
+        self.sigma_w = float(sigma_w)
+        self.sigma_eps = float(sigma_eps)
+        self.n_tasks = n_tasks
+        self.seed = seed
+        self.device = device or torch.device("cpu")
+        self.dtype = dtype
+
+        generator = torch.Generator(device="cpu")
+        generator.manual_seed(seed)
+
+        self._w_star = self._sample_w(generator)
+        self._Xc, eps_c = self._sample_inputs(generator, n_context)
+        self._Xq, eps_q = self._sample_inputs(generator, n_query)
+
+        self._yc = (self._Xc @ self._w_star.unsqueeze(-1)).squeeze(-1) + eps_c
+        self._yq = (self._Xq @ self._w_star.unsqueeze(-1)).squeeze(-1) + eps_q
+
+        self._move_to_device()
+
+    def _sample_w(self, generator: torch.Generator) -> torch.Tensor:
+        w = torch.randn(self.n_tasks, self.d, generator=generator, dtype=self.dtype)
+        return w * self.sigma_w
+
+    def _sample_inputs(
+        self, generator: torch.Generator, n_points: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        x = torch.randn(
+            self.n_tasks, n_points, self.d, generator=generator, dtype=self.dtype
+        )
+        noise = torch.randn(
+            self.n_tasks, n_points, generator=generator, dtype=self.dtype
+        ) * self.sigma_eps
+        return x, noise
+
+    def _move_to_device(self) -> None:
+        if self.device is None:
+            return
+        self._w_star = self._w_star.to(self.device)
+        self._Xc = self._Xc.to(self.device)
+        self._Xq = self._Xq.to(self.device)
+        self._yc = self._yc.to(self.device)
+        self._yq = self._yq.to(self.device)
+
+    def __len__(self) -> int:
+        return self.n_tasks
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        if idx < 0 or idx >= self.n_tasks:
+            raise IndexError(idx)
+        return {
+            "Xc": self._Xc[idx],
+            "yc": self._yc[idx],
+            "Xq": self._Xq[idx],
+            "yq": self._yq[idx],
+            "w_star": self._w_star[idx],
+        }
+
+    def ridge_solution(self, lam: float = 0.0) -> torch.Tensor:
+        """Return the closed-form ridge estimator for each task."""
+
+        eye = torch.eye(self.d, dtype=self.dtype, device=self.device)
+        XtX = torch.matmul(self._Xc.transpose(-1, -2), self._Xc)
+        Xty = torch.matmul(self._Xc.transpose(-1, -2), self._yc.unsqueeze(-1))
+        lam_eye = (lam + 1e-6) * eye
+        w_hat = torch.linalg.solve(XtX + lam_eye, Xty)
+        return w_hat.squeeze(-1)
+
+    def ridge_mse(self, lam: float = 0.0) -> torch.Tensor:
+        """Return query MSE of the ridge solution averaged over tasks."""
+
+        w_hat = self.ridge_solution(lam)
+        preds = torch.einsum("tqd,td->tq", self._Xq, w_hat)
+        mse = (preds - self._yq) ** 2
+        return mse.mean(dim=1)
+
+
+def quick_sanity_check() -> bool:
+    """Return True if ridge solution achieves noise-level MSE within tolerance."""
+
+    taskset = LinearRegressionTaskset(
+        d=5,
+        n_context=20,
+        n_query=20,
+        sigma_w=1.0,
+        sigma_eps=0.05,
+        n_tasks=8,
+        seed=0,
+    )
+    mse = taskset.ridge_mse().mean()
+    return torch.isclose(mse, torch.tensor(taskset.sigma_eps**2), rtol=0.5, atol=0.5)
+
+
+if __name__ == "__main__":
+    assert quick_sanity_check(), "Ridge solution sanity check failed."

--- a/experiments/ic_gd/eval_layerwise.py
+++ b/experiments/ic_gd/eval_layerwise.py
@@ -1,0 +1,119 @@
+"""Evaluate layerwise losses of a trained transformer checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import torch
+from torch.utils.data import DataLoader
+
+from .data import LinearRegressionTaskset
+from .heads import LayerwisePredictor, LinearReadout
+from .train_transformer import ICGDTransformer, _collate
+
+
+def load_meta(meta_path: Path) -> Dict:
+    with meta_path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def compute_per_task_losses(pred: torch.Tensor, targets: torch.Tensor, query_mask: torch.Tensor) -> torch.Tensor:
+    if query_mask.dim() == 1:
+        mask = query_mask.bool().unsqueeze(0).expand_as(pred)
+    else:
+        mask = query_mask.bool()
+    masked_errors = (pred - targets) ** 2 * mask
+    denom = mask.sum(dim=-1).clamp_min(1)
+    return masked_errors.sum(dim=-1) / denom
+
+
+def evaluate_layerwise(
+    predictor: LayerwisePredictor,
+    loader: DataLoader,
+    device: torch.device,
+) -> Dict[str, List[float]]:
+    per_layer_losses: List[List[float]] = []
+    predictor.eval()
+    with torch.no_grad():
+        for batch in loader:
+            batch = {k: v.to(device) for k, v in batch.items()}
+            outputs = predictor.forward(batch)
+            preds = outputs["preds"]
+            for layer_idx, pred in enumerate(preds):
+                losses = compute_per_task_losses(pred, batch["targets"], batch["query_mask"])
+                if layer_idx >= len(per_layer_losses):
+                    per_layer_losses.append([])
+                per_layer_losses[layer_idx].extend(losses.cpu().tolist())
+    predictor.train()
+
+    mse = [float(torch.tensor(losses).mean()) for losses in per_layer_losses]
+    sem = [
+        float(torch.tensor(losses).std(unbiased=False) / (len(losses) ** 0.5))
+        for losses in per_layer_losses
+    ]
+    return {
+        "layers": list(range(1, len(per_layer_losses) + 1)),
+        "mse": mse,
+        "sem": sem,
+    }
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", required=True, help="Path to checkpoint (best.pt)")
+    parser.add_argument("--nsamples", type=int, default=5000)
+    parser.add_argument("--save_dir", required=True)
+    args = parser.parse_args(argv)
+
+    ckpt_path = Path(args.ckpt)
+    save_dir = Path(args.save_dir)
+    meta = load_meta(ckpt_path.parent / "meta.json")
+    config = meta["config"]
+
+    dataset_cfg = config["dataset"].copy()
+    dataset_cfg["n_tasks"] = args.nsamples
+    dataset_cfg["seed"] = config.get("seed", 0) + 123
+
+    dataset = LinearRegressionTaskset(**dataset_cfg)
+    loader = DataLoader(
+        dataset,
+        batch_size=config["training"]["batch_size"],
+        shuffle=False,
+        drop_last=False,
+        collate_fn=_collate,
+    )
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    seq_len = dataset_cfg["n_context"] + dataset_cfg["n_query"]
+    model_cfg = config["model"]
+    model = ICGDTransformer(
+        input_dim=dataset_cfg["d"] + 2,
+        d_model=model_cfg["d_model"],
+        n_heads=model_cfg["n_heads"],
+        depth=model_cfg["depth"],
+        ff_mult=model_cfg.get("ff_mult", 4),
+        dropout=model_cfg.get("dropout", 0.0),
+        seq_len=seq_len,
+    ).to(device)
+    readout = LinearReadout(model_cfg["d_model"]).to(device)
+
+    state = torch.load(ckpt_path, map_location=device)
+    model.load_state_dict(state["model"])
+    readout.load_state_dict(state["readout"])
+
+    predictor = LayerwisePredictor(model, readout)
+    metrics = evaluate_layerwise(predictor, loader, device)
+
+    save_dir.mkdir(parents=True, exist_ok=True)
+    out_file = save_dir / "layerwise_metrics.json"
+    with out_file.open("w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2)
+    print(json.dumps(metrics, indent=2))
+    print(f"Saved layerwise metrics to {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/ic_gd/gd_baseline.py
+++ b/experiments/ic_gd/gd_baseline.py
@@ -1,0 +1,154 @@
+"""Exact gradient-descent baseline for linear regression tasks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import torch
+
+from .data import LinearRegressionTaskset
+
+
+def _ridge_init(
+    Xc: torch.Tensor, yc: torch.Tensor, ridge: float = 0.0
+) -> torch.Tensor:
+    d = Xc.shape[-1]
+    eye = torch.eye(d, dtype=Xc.dtype, device=Xc.device)
+    XtX = Xc.T @ Xc
+    Xty = Xc.T @ yc
+    return torch.linalg.solve(XtX + ridge * eye, Xty)
+
+
+def gd_predict(
+    Xc: torch.Tensor,
+    yc: torch.Tensor,
+    Xq: torch.Tensor,
+    lr: float,
+    steps: int,
+    init: str = "zero",
+    ridge: float = 0.0,
+) -> List[torch.Tensor]:
+    """Return predictions on ``Xq`` after each GD step."""
+
+    if steps <= 0:
+        raise ValueError("steps must be positive")
+    if lr <= 0:
+        raise ValueError("learning rate must be positive")
+
+    Xc = Xc.float()
+    yc = yc.float()
+    Xq = Xq.float()
+    n_context = Xc.shape[0]
+    d = Xc.shape[1]
+
+    if init == "zero":
+        w = torch.zeros(d, dtype=Xc.dtype, device=Xc.device)
+    elif init == "ridge":
+        w = _ridge_init(Xc, yc, ridge=ridge)
+    else:
+        raise ValueError(f"Unknown init '{init}'")
+
+    preds: List[torch.Tensor] = []
+    for _ in range(steps):
+        grad = (Xc.T @ (Xc @ w - yc)) / n_context
+        if ridge > 0:
+            grad = grad + ridge * w
+        w = w - lr * grad
+        preds.append(Xq @ w)
+    return preds
+
+
+def _safe_lr(Xc: torch.Tensor) -> float:
+    cov = (Xc.T @ Xc) / Xc.shape[0]
+    eigvals = torch.linalg.eigvalsh(cov)
+    max_eig = eigvals.max().item()
+    if max_eig <= 0:
+        return 1.0
+    return 1.0 / (max_eig + 1e-12)
+
+
+def gd_curve(
+    taskset: Sequence[dict],
+    lr: float,
+    steps: int,
+    lr_search: bool = False,
+    init: str = "zero",
+    ridge: float = 0.0,
+) -> dict:
+    """Compute mean/sem query MSE across tasks for GD baseline."""
+
+    per_task_losses: List[torch.Tensor] = []
+    for task in taskset:
+        Xc = task["Xc"].to(torch.float32)
+        yc = task["yc"].to(torch.float32)
+        Xq = task["Xq"].to(torch.float32)
+        yq = task["yq"].to(torch.float32)
+        task_lr = _safe_lr(Xc) if lr_search else lr
+        preds = gd_predict(Xc, yc, Xq, task_lr, steps, init=init, ridge=ridge)
+        losses = [torch.mean((p - yq) ** 2) for p in preds]
+        per_task_losses.append(torch.stack(losses))
+
+    loss_matrix = torch.stack(per_task_losses)
+    mean = loss_matrix.mean(dim=0)
+    sem = loss_matrix.std(dim=0, unbiased=False) / math.sqrt(len(taskset))
+    return {
+        "mse": mean.tolist(),
+        "sem": sem.tolist(),
+        "steps": list(range(1, steps + 1)),
+    }
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--d", type=int, required=True)
+    parser.add_argument("--n_context", type=int, required=True)
+    parser.add_argument("--n_query", type=int, required=True)
+    parser.add_argument("--sigma_w", type=float, required=True)
+    parser.add_argument("--sigma_eps", type=float, required=True)
+    parser.add_argument("--n_tasks", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--steps", type=int, default=50)
+    parser.add_argument("--lr", type=float, default=0.1)
+    parser.add_argument("--lr_search", action="store_true")
+    parser.add_argument("--init", choices=["zero", "ridge"], default="zero")
+    parser.add_argument("--ridge", type=float, default=0.0)
+    parser.add_argument("--save_dir", type=str, required=True)
+    return parser
+
+
+def main(args: Iterable[str] | None = None) -> None:
+    parser = _build_arg_parser()
+    parsed = parser.parse_args(args=args)
+
+    taskset = LinearRegressionTaskset(
+        d=parsed.d,
+        n_context=parsed.n_context,
+        n_query=parsed.n_query,
+        sigma_w=parsed.sigma_w,
+        sigma_eps=parsed.sigma_eps,
+        n_tasks=parsed.n_tasks,
+        seed=parsed.seed,
+    )
+    metrics = gd_curve(
+        taskset,
+        lr=parsed.lr,
+        steps=parsed.steps,
+        lr_search=parsed.lr_search,
+        init=parsed.init,
+        ridge=parsed.ridge,
+    )
+
+    save_dir = Path(parsed.save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+    out_file = save_dir / "gd_metrics.json"
+    with out_file.open("w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2)
+    print(f"Saved GD metrics to {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/ic_gd/heads.py
+++ b/experiments/ic_gd/heads.py
@@ -1,0 +1,58 @@
+"""Shared readout heads and layerwise evaluation helpers."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import torch
+from torch import nn
+
+from .io import compute_query_loss
+
+
+class LinearReadout(nn.Module):
+    """Linear projection applied to hidden states of query tokens."""
+
+    def __init__(self, d_model: int) -> None:
+        super().__init__()
+        self.proj = nn.Linear(d_model, 1)
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        return self.proj(hidden).squeeze(-1)
+
+
+class LayerwisePredictor(nn.Module):
+    """Evaluate a transformer using a shared readout on each layer."""
+
+    def __init__(self, transformer: nn.Module, readout: LinearReadout) -> None:
+        super().__init__()
+        self.transformer = transformer
+        self.readout = readout
+
+    def forward(self, batch: Dict[str, torch.Tensor]) -> Dict[str, List[torch.Tensor]]:
+        outputs = self.transformer(
+            batch["tokens"],
+            attention_mask=batch.get("attention_mask"),
+            type_ids=batch.get("type_ids"),
+            position_ids=batch.get("position_ids"),
+            return_layer_states=True,
+        )
+        layer_states: List[torch.Tensor] = outputs["layer_states"]
+        preds = [self.readout(h) for h in layer_states]
+        return {"preds": preds, "layer_states": layer_states}
+
+    @torch.no_grad()
+    def evaluate(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
+        """Return per-layer MSE on query tokens."""
+
+        result = self.forward(batch)
+        preds = result["preds"]
+        losses = []
+        for pred in preds:
+            loss = compute_query_loss(
+                pred,
+                batch["targets"],
+                batch["query_mask"],
+            )
+            losses.append(loss.detach())
+        return torch.stack(losses)

--- a/experiments/ic_gd/io.py
+++ b/experiments/ic_gd/io.py
@@ -1,0 +1,83 @@
+"""Packing utilities to interface linear tasks with the transformer."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import torch
+
+
+def pack_sequence(
+    Xc: torch.Tensor, yc: torch.Tensor, Xq: torch.Tensor, yq: Optional[torch.Tensor] = None
+) -> Dict[str, torch.Tensor]:
+    """Pack context/query pairs into a single transformer-friendly sequence."""
+
+    if Xc.dim() != 2 or Xq.dim() != 2:
+        raise ValueError("Xc and Xq must be 2D tensors")
+    if yc.dim() != 1:
+        raise ValueError("yc must be a 1D tensor")
+    if Xc.shape[0] != yc.shape[0]:
+        raise ValueError("Context inputs/targets mismatch")
+    if Xc.shape[1] != Xq.shape[1]:
+        raise ValueError("Context/query feature dimension mismatch")
+
+    n_context = Xc.shape[0]
+    n_query = Xq.shape[0]
+    d = Xc.shape[1]
+    seq_len = n_context + n_query
+
+    tokens = torch.zeros(seq_len, d + 2, dtype=Xc.dtype, device=Xc.device)
+    tokens[:n_context, :d] = Xc
+    tokens[:n_context, d] = yc
+    tokens[n_context:, :d] = Xq
+    tokens[n_context:, d] = 0.0
+    tokens[n_context:, d + 1] = 1.0  # query indicator
+
+    attention_mask = torch.ones(seq_len, seq_len, dtype=torch.bool, device=Xc.device)
+    # Disallow attending to future queries
+    for i in range(n_query):
+        q_idx = n_context + i
+        attention_mask[q_idx, n_context + i + 1 :] = False
+
+    type_ids = torch.zeros(seq_len, dtype=torch.long, device=Xc.device)
+    type_ids[n_context:] = 1
+    position_ids = torch.arange(seq_len, device=Xc.device)
+    query_mask = torch.zeros(seq_len, dtype=torch.bool, device=Xc.device)
+    query_mask[n_context:] = True
+
+    targets = torch.cat(
+        [
+            yc,
+            yq if yq is not None else torch.zeros(n_query, dtype=yc.dtype, device=yc.device),
+        ]
+    )
+
+    return {
+        "tokens": tokens,
+        "attention_mask": attention_mask,
+        "type_ids": type_ids,
+        "position_ids": position_ids,
+        "query_mask": query_mask,
+        "targets": targets,
+    }
+
+
+def compute_query_loss(
+    preds: torch.Tensor, targets: torch.Tensor, query_mask: torch.Tensor
+) -> torch.Tensor:
+    """Compute MSE on query positions only."""
+
+    if preds.shape != targets.shape:
+        raise ValueError("Predictions and targets shape mismatch")
+    if query_mask.dim() == 1:
+        mask = query_mask
+    elif query_mask.dim() == preds.dim():
+        mask = query_mask
+    else:
+        mask = query_mask.unsqueeze(0).expand_as(preds)
+
+    masked = preds[mask]
+    masked_targets = targets[mask]
+    if masked.numel() == 0:
+        raise ValueError("Query mask selects no elements")
+    return torch.mean((masked - masked_targets) ** 2)

--- a/experiments/ic_gd/plot_compare.py
+++ b/experiments/ic_gd/plot_compare.py
@@ -1,0 +1,69 @@
+"""Plot GD baseline and transformer layerwise curves on one figure."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+
+def load_metrics(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def plot_curves(gd_metrics: dict, tr_metrics: dict, out_path: Path) -> None:
+    plt.figure(figsize=(6, 4))
+    gd_sem = gd_metrics.get("sem") or [0.0] * len(gd_metrics["steps"])
+    plt.plot(gd_metrics["steps"], gd_metrics["mse"], label="GD Steps", color="green")
+    plt.fill_between(
+        gd_metrics["steps"],
+        [m - s for m, s in zip(gd_metrics["mse"], gd_sem)],
+        [m + s for m, s in zip(gd_metrics["mse"], gd_sem)],
+        color="green",
+        alpha=0.2,
+    )
+
+    tr_sem = tr_metrics.get("sem") or [0.0] * len(tr_metrics["layers"])
+    plt.plot(
+        tr_metrics["layers"],
+        tr_metrics["mse"],
+        label="Transformer Layers",
+        color="purple",
+        marker="o",
+    )
+    plt.fill_between(
+        tr_metrics["layers"],
+        [m - s for m, s in zip(tr_metrics["mse"], tr_sem)],
+        [m + s for m, s in zip(tr_metrics["mse"], tr_sem)],
+        color="purple",
+        alpha=0.2,
+    )
+
+    plt.xlabel("Steps / Layers")
+    plt.ylabel("Query MSE")
+    plt.legend()
+    plt.grid(True, alpha=0.3)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.tight_layout()
+    plt.savefig(out_path)
+    plt.close()
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gd", required=True, help="Path to GD baseline JSON")
+    parser.add_argument("--tr", required=True, help="Path to transformer layerwise JSON")
+    parser.add_argument("--out", required=True, help="Output path (png)")
+    args = parser.parse_args(argv)
+
+    gd_metrics = load_metrics(Path(args.gd))
+    tr_metrics = load_metrics(Path(args.tr))
+    plot_curves(gd_metrics, tr_metrics, Path(args.out))
+    print(f"Saved comparison plot to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/ic_gd/run_depth_sweep.sh
+++ b/experiments/ic_gd/run_depth_sweep.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=${1:-"experiments/ic_gd/configs/linreg.yaml"}
+DEPTHS=(2 4 8 12 24)
+for L in "${DEPTHS[@]}"; do
+  python experiments/ic_gd/train_transformer.py --config "$CONFIG" save_dir=runs/ic_gd/d20_L${L} L=${L}
+done

--- a/experiments/ic_gd/train_transformer.py
+++ b/experiments/ic_gd/train_transformer.py
@@ -1,0 +1,335 @@
+"""Training entry point for the in-context GD replication experiment."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+import yaml
+
+from .data import LinearRegressionTaskset
+from .heads import LinearReadout
+from .io import compute_query_loss, pack_sequence
+from .utils import collect_meta, set_seed, write_meta
+
+
+class ICGDTransformer(nn.Module):
+    """Simple Transformer encoder that returns layer-wise hidden states."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        d_model: int,
+        n_heads: int,
+        depth: int,
+        ff_mult: int = 4,
+        dropout: float = 0.0,
+        seq_len: int = 0,
+    ) -> None:
+        super().__init__()
+        self.input_proj = nn.Linear(input_dim, d_model)
+        self.layers = nn.ModuleList(
+            [
+                nn.TransformerEncoderLayer(
+                    d_model,
+                    nhead=n_heads,
+                    dim_feedforward=d_model * ff_mult,
+                    dropout=dropout,
+                    activation="gelu",
+                    batch_first=True,
+                )
+                for _ in range(depth)
+            ]
+        )
+        self.norm = nn.LayerNorm(d_model)
+        if seq_len > 0:
+            self.positional = nn.Parameter(torch.zeros(1, seq_len, d_model))
+            self.position_embedding = nn.Embedding(seq_len, d_model)
+        else:
+            self.register_parameter("positional", None)
+            self.position_embedding = None
+        self.type_embedding = nn.Embedding(2, d_model)
+
+    def forward(
+        self,
+        tokens: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        type_ids: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        return_layer_states: bool = False,
+    ) -> Dict[str, List[torch.Tensor]] | torch.Tensor:
+        x = self.input_proj(tokens)
+        if self.positional is not None:
+            x = x + self.positional
+        if type_ids is not None:
+            x = x + self.type_embedding(type_ids)
+        if position_ids is not None and self.position_embedding is not None:
+            x = x + self.position_embedding(position_ids)
+
+        src_mask = None
+        if attention_mask is not None:
+            src_mask = ~attention_mask.bool()
+
+        layer_states = []
+        for layer in self.layers:
+            x = layer(x, src_mask=src_mask)
+            layer_states.append(x)
+        x = self.norm(x)
+        layer_states[-1] = x
+        if return_layer_states:
+            return {"layer_states": layer_states, "final": x}
+        return x
+
+
+def _cycle(loader: Iterable) -> Iterator:
+    while True:
+        for batch in loader:
+            yield batch
+
+
+def _collate(batch: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
+    packed = [
+        pack_sequence(sample["Xc"], sample["yc"], sample["Xq"], sample["yq"]) for sample in batch
+    ]
+    tokens = torch.stack([item["tokens"] for item in packed])
+    attention_mask = packed[0]["attention_mask"]
+    type_ids = torch.stack([item["type_ids"] for item in packed])
+    position_ids = torch.stack([item["position_ids"] for item in packed])
+    targets = torch.stack([item["targets"] for item in packed])
+    query_mask = packed[0]["query_mask"].unsqueeze(0).expand(len(batch), -1)
+    return {
+        "tokens": tokens,
+        "attention_mask": attention_mask,
+        "type_ids": type_ids,
+        "position_ids": position_ids,
+        "targets": targets,
+        "query_mask": query_mask,
+    }
+
+
+def _parse_overrides(unknown: List[str]) -> Dict[str, str]:
+    overrides: Dict[str, str] = {}
+    for item in unknown:
+        if "=" not in item:
+            raise ValueError(f"Cannot parse override '{item}'")
+        key, value = item.split("=", 1)
+        overrides[key.strip()] = value.strip()
+    return overrides
+
+
+def _apply_overrides(config: Dict, overrides: Dict[str, str]) -> Dict:
+    mapping = {
+        "d": ("dataset", "d"),
+        "n_context": ("dataset", "n_context"),
+        "n_query": ("dataset", "n_query"),
+        "sigma_w": ("dataset", "sigma_w"),
+        "sigma_eps": ("dataset", "sigma_eps"),
+        "n_tasks": ("dataset", "n_tasks"),
+        "d_model": ("model", "d_model"),
+        "n_heads": ("model", "n_heads"),
+        "ffw_mult": ("model", "ff_mult"),
+        "ff_mult": ("model", "ff_mult"),
+        "L": ("model", "depth"),
+        "depth": ("model", "depth"),
+        "dropout": ("model", "dropout"),
+        "batch_size": ("training", "batch_size"),
+        "lr": ("training", "lr"),
+        "wd": ("training", "weight_decay"),
+        "weight_decay": ("training", "weight_decay"),
+        "steps": ("training", "steps"),
+        "warmup": ("training", "warmup"),
+        "grad_clip": ("training", "grad_clip"),
+        "eval_interval": ("training", "eval_interval"),
+        "save_dir": (None, "save_dir"),
+        "seed": (None, "seed"),
+    }
+    for key, value in overrides.items():
+        if key not in mapping:
+            raise ValueError(f"Unknown override '{key}'")
+        group, name = mapping[key]
+        target = config if group is None else config.setdefault(group, {})
+        if name in {"d", "n_context", "n_query", "n_tasks", "depth", "n_heads", "batch_size", "steps", "warmup", "eval_interval", "seed"}:
+            cast_value = int(value)
+        elif name in {"sigma_w", "sigma_eps", "lr", "weight_decay", "grad_clip", "dropout"}:
+            cast_value = float(value)
+        else:
+            cast_value = value
+        target[name] = cast_value
+    return config
+
+
+def _build_optimizer(params, lr: float, weight_decay: float) -> torch.optim.Optimizer:
+    return torch.optim.AdamW(params, lr=lr, weight_decay=weight_decay)
+
+
+def _lr_lambda(step: int, warmup: int) -> float:
+    if warmup <= 0:
+        return 1.0
+    return min(1.0, (step + 1) / warmup)
+
+
+def evaluate(
+    model: ICGDTransformer,
+    readout: LinearReadout,
+    loader: DataLoader,
+    device: torch.device,
+) -> float:
+    model.eval()
+    readout.eval()
+    losses: List[float] = []
+    with torch.no_grad():
+        for batch in loader:
+            batch = {k: v.to(device) for k, v in batch.items()}
+            outputs = model(
+                batch["tokens"],
+                attention_mask=batch["attention_mask"],
+                type_ids=batch["type_ids"],
+                position_ids=batch["position_ids"],
+                return_layer_states=True,
+            )
+            preds = readout(outputs["layer_states"][-1])
+            loss = compute_query_loss(preds, batch["targets"], batch["query_mask"])
+            losses.append(loss.item())
+    model.train()
+    readout.train()
+    return float(sum(losses) / max(1, len(losses)))
+
+
+def train(config: Dict[str, Dict]) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    set_seed(config.get("seed", 0))
+
+    dataset_cfg = config["dataset"]
+    dataset = LinearRegressionTaskset(**dataset_cfg)
+    dataloader = DataLoader(
+        dataset,
+        batch_size=config["training"]["batch_size"],
+        shuffle=True,
+        drop_last=True,
+        collate_fn=_collate,
+    )
+    iterator = _cycle(dataloader)
+
+    seq_len = dataset_cfg["n_context"] + dataset_cfg["n_query"]
+    model_cfg = config["model"]
+    model = ICGDTransformer(
+        input_dim=dataset_cfg["d"] + 2,
+        d_model=model_cfg["d_model"],
+        n_heads=model_cfg["n_heads"],
+        depth=model_cfg["depth"],
+        ff_mult=model_cfg.get("ff_mult", 4),
+        dropout=model_cfg.get("dropout", 0.0),
+        seq_len=seq_len,
+    ).to(device)
+    readout = LinearReadout(model_cfg["d_model"]).to(device)
+
+    optimizer = _build_optimizer(
+        itertools.chain(model.parameters(), readout.parameters()),
+        lr=config["training"]["lr"],
+        weight_decay=config["training"].get("weight_decay", 0.0),
+    )
+    scheduler = torch.optim.lr_scheduler.LambdaLR(
+        optimizer,
+        lr_lambda=lambda step: _lr_lambda(step, config["training"].get("warmup", 0)),
+    )
+
+    eval_dataset = LinearRegressionTaskset(
+        **{**dataset_cfg, "n_tasks": config.get("eval", {}).get("nsamples", 1024), "seed": dataset_cfg["seed"] + 1}
+    )
+    eval_loader = DataLoader(
+        eval_dataset,
+        batch_size=config["training"]["batch_size"],
+        shuffle=False,
+        drop_last=False,
+        collate_fn=_collate,
+    )
+
+    save_dir = Path(config.get("save_dir", "runs/ic_gd/default"))
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    meta = collect_meta(config, config.get("seed", 0), save_dir)
+    write_meta(save_dir, meta)
+
+    best_loss = float("inf")
+    best_state = None
+    total_steps = config["training"]["steps"]
+    eval_interval = config["training"].get("eval_interval", 1000)
+
+    for step in range(1, total_steps + 1):
+        batch = next(iterator)
+        batch = {k: v.to(device) for k, v in batch.items()}
+
+        outputs = model(
+            batch["tokens"],
+            attention_mask=batch["attention_mask"],
+            type_ids=batch["type_ids"],
+            position_ids=batch["position_ids"],
+            return_layer_states=True,
+        )
+        preds = readout(outputs["layer_states"][-1])
+        loss = compute_query_loss(preds, batch["targets"], batch["query_mask"])
+
+        optimizer.zero_grad()
+        loss.backward()
+        if config["training"].get("grad_clip", 0.0) > 0:
+            torch.nn.utils.clip_grad_norm_(
+                itertools.chain(model.parameters(), readout.parameters()),
+                config["training"]["grad_clip"],
+            )
+        optimizer.step()
+        scheduler.step()
+
+        if step % eval_interval == 0 or step == total_steps:
+            val_loss = evaluate(model, readout, eval_loader, device)
+            print(f"Step {step}: train_loss={loss.item():.4f} val_loss={val_loss:.4f}")
+            if val_loss < best_loss:
+                best_loss = val_loss
+                best_state = {
+                    "model": model.state_dict(),
+                    "readout": readout.state_dict(),
+                    "step": step,
+                    "val_loss": val_loss,
+                }
+                torch.save(best_state, save_dir / "best.pt")
+
+    torch.save(
+        {
+            "model": model.state_dict(),
+            "readout": readout.state_dict(),
+            "step": total_steps,
+            "val_loss": best_loss,
+        },
+        save_dir / "last.pt",
+    )
+
+
+def load_config(args: Iterable[str]) -> Dict:
+    parser = argparse.ArgumentParser(description=__doc__, add_help=False)
+    parser.add_argument("--config", type=str, default=None)
+    parser.add_argument("--help", action="help")
+    parsed, unknown = parser.parse_known_args(args)
+
+    if parsed.config:
+        with open(parsed.config, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+    else:
+        with open(Path(__file__).parent / "configs" / "linreg.yaml", "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+
+    overrides = _parse_overrides(unknown)
+    config = _apply_overrides(config, overrides)
+    return config
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    config = load_config(argv)
+    train(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/ic_gd/utils.py
+++ b/experiments/ic_gd/utils.py
@@ -1,0 +1,56 @@
+"""Utility helpers for reproducibility and logging."""
+
+from __future__ import annotations
+
+import json
+import platform
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import torch
+
+
+def set_seed(seed: int) -> None:
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+@dataclass
+class MetaInfo:
+    git_hash: str
+    config: Dict[str, Any]
+    seed: int
+    device: str
+    torch_version: str
+    platform: str
+
+
+def write_meta(save_dir: Path, meta: MetaInfo) -> None:
+    save_dir.mkdir(parents=True, exist_ok=True)
+    with (save_dir / "meta.json").open("w", encoding="utf-8") as f:
+        json.dump(asdict(meta), f, indent=2)
+
+
+def collect_meta(config: Dict[str, Any], seed: int, save_dir: Path) -> MetaInfo:
+    git_hash = "unknown"
+    try:
+        import subprocess
+
+        git_hash = (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=Path.cwd())
+            .decode("utf-8")
+            .strip()
+        )
+    except Exception:
+        pass
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    return MetaInfo(
+        git_hash=git_hash,
+        config=config,
+        seed=seed,
+        device=device,
+        torch_version=torch.__version__,
+        platform=platform.platform(),
+    )

--- a/tests/test_ic_gd.py
+++ b/tests/test_ic_gd.py
@@ -1,0 +1,125 @@
+import torch
+from pathlib import Path
+
+from torch.utils.data import DataLoader
+
+from experiments.ic_gd.data import LinearRegressionTaskset
+from experiments.ic_gd.gd_baseline import gd_curve
+from experiments.ic_gd.heads import LayerwisePredictor, LinearReadout
+from experiments.ic_gd.eval_layerwise import evaluate_layerwise
+from experiments.ic_gd.train_transformer import ICGDTransformer, _collate, train
+
+
+def test_linear_regression_taskset_deterministic():
+    taskset_a = LinearRegressionTaskset(
+        d=4,
+        n_context=6,
+        n_query=5,
+        sigma_w=1.0,
+        sigma_eps=0.1,
+        n_tasks=3,
+        seed=123,
+    )
+    taskset_b = LinearRegressionTaskset(
+        d=4,
+        n_context=6,
+        n_query=5,
+        sigma_w=1.0,
+        sigma_eps=0.1,
+        n_tasks=3,
+        seed=123,
+    )
+
+    assert len(taskset_a) == 3
+    sample = taskset_a[0]
+    assert sample["Xc"].shape == (6, 4)
+    assert sample["yc"].shape == (6,)
+    assert sample["Xq"].shape == (5, 4)
+    assert sample["yq"].shape == (5,)
+
+    for idx in range(3):
+        a = taskset_a[idx]
+        b = taskset_b[idx]
+        for key in ["Xc", "yc", "Xq", "yq", "w_star"]:
+            assert torch.allclose(a[key], b[key])
+
+
+def test_gd_curve_monotonic():
+    taskset = LinearRegressionTaskset(
+        d=5,
+        n_context=12,
+        n_query=6,
+        sigma_w=1.0,
+        sigma_eps=0.1,
+        n_tasks=32,
+        seed=0,
+    )
+    metrics = gd_curve(taskset, lr=0.1, steps=6, lr_search=True)
+    mse = metrics["mse"]
+    assert all(mse[i] <= mse[i - 1] + 1e-6 for i in range(1, len(mse)))
+
+
+def test_transformer_overfits_and_layerwise(tmp_path):
+    config = {
+        "seed": 0,
+        "save_dir": str(tmp_path / "run"),
+        "dataset": {
+            "d": 4,
+            "n_context": 6,
+            "n_query": 6,
+            "sigma_w": 1.0,
+            "sigma_eps": 0.0,
+            "n_tasks": 128,
+            "seed": 0,
+        },
+        "model": {
+            "d_model": 32,
+            "n_heads": 2,
+            "ff_mult": 2,
+            "depth": 3,
+            "dropout": 0.0,
+        },
+        "training": {
+            "batch_size": 16,
+            "steps": 60,
+            "lr": 5e-4,
+            "weight_decay": 0.0,
+            "warmup": 0,
+            "eval_interval": 30,
+            "grad_clip": 0.0,
+        },
+        "eval": {"nsamples": 64},
+    }
+    train(config)
+
+    ckpt = Path(config["save_dir"]) / "best.pt"
+    state = torch.load(ckpt, map_location="cpu")
+    assert state["val_loss"] < 1e-2
+
+    dataset = LinearRegressionTaskset(**config["dataset"], n_tasks=32)
+    loader = DataLoader(
+        dataset,
+        batch_size=16,
+        shuffle=False,
+        drop_last=False,
+        collate_fn=_collate,
+    )
+
+    model = ICGDTransformer(
+        input_dim=config["dataset"]["d"] + 2,
+        d_model=config["model"]["d_model"],
+        n_heads=config["model"]["n_heads"],
+        depth=config["model"]["depth"],
+        ff_mult=config["model"].get("ff_mult", 2),
+        dropout=0.0,
+        seq_len=config["dataset"]["n_context"] + config["dataset"]["n_query"],
+    )
+    readout = LinearReadout(config["model"]["d_model"])
+    model.load_state_dict(state["model"])
+    readout.load_state_dict(state["readout"])
+
+    predictor = LayerwisePredictor(model, readout)
+    metrics = evaluate_layerwise(predictor, loader, torch.device("cpu"))
+    mse = metrics["mse"]
+    for i in range(1, len(mse)):
+        assert mse[i] <= mse[i - 1] + 1e-2


### PR DESCRIPTION
## Summary
- add an in-context gradient descent experiment stack with dataset sampling, GD baseline, IO utilities, shared readouts, training/eval scripts, plotting, and configs
- implement layerwise evaluation and plotting helpers plus a run script for depth sweeps
- include pytest-based regression tests for the sampler, GD baseline monotonicity, and transformer overfitting behaviour

## Testing
- ⚠️ `pytest tests/test_ic_gd.py` *(fails to run because PyTorch is unavailable in the execution environment and could not be installed due to proxy restrictions)*